### PR TITLE
Issue #0000 chore:Copy Of Content Player inside assets using ionic co…

### DIFF
--- a/config/copy.config.js
+++ b/config/copy.config.js
@@ -1,0 +1,8 @@
+const config = require('@ionic/app-scripts/config/copy.config');
+
+module.exports = Object.assign(config, {
+    copyContentPlayer: {
+      src: ['{{ROOT}}/content-player/**/*'],
+      dest: '{{BUILD}}//content-player/'
+    }
+  });

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -9,16 +9,7 @@ const customConfig = {
     alias: {
       '@app': path.resolve('src'),
     }
-  },
-  plugins: [
-    new CopyWebpackPlugin([
-      {
-        from: './content-player/',
-        to: './content-player',
-        toType: 'file'
-      }
-    ]),
-  ]
+  }
 };
 
 module.exports = function () {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ionic_source_map_type": "inline-source-map",
     "ionic_webpack": "./config/webpack.config.js",
     "ionic_sass": "./config/sass.config.js",
+    "ionic_copy": "./config/copy.config.js",
     "ionic_enable_lint": false
   },
   "dependencies": {


### PR DESCRIPTION
Copy Of Content Player inside assets using ionic copy config rather than webpack config file. This is the requirement of player today. It would be better to optimize the content-player  as it would reduce the size of apk drastically 